### PR TITLE
Fixing an error when this module is imported into a node environment …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,8 +34,8 @@ const ms = [
   'MSFullscreenError',
 ];
 
-// so it doesn't throw if no document
-const document = typeof window.document !== undefined ? window.document : {};
+// so it doesn't throw if no window or document
+const document = typeof window !== 'undefined' && typeof window.document !== 'undefined' ? window.document : {};
 
 const vendor = (
   ('fullscreenEnabled' in document && Object.keys(key)) ||


### PR DESCRIPTION
…for server side rendering.

I'd like to use this module in a project that utilizing server side rendering with react.  Unfortunately, it crashes the application due to this variable assignment dying before "window" exists.

This change ensures that a check for the window object fires first so that consumers of this library don't have to inject a global "window" object into their node environment.

additionally the check for `typeof window.document` was updated to check for the string value of 'undefined' instead of the undefined object since typeof outputs a string representation of the type being tested (typeof undefined === 'undefined').